### PR TITLE
Support `#![no_std]` crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ extern crate proc_macro2;
 extern crate syn;
 #[macro_use]
 extern crate synstructure;
+extern crate core;
 
 use proc_macro2::TokenStream;
 use syn::{parse_str, Fields, Ident, Lit, Meta, NestedMeta, Path};
@@ -62,11 +63,11 @@ fn custom_debug_derive(mut s: Structure) -> TokenStream {
                                         &{
                                             struct DebugWith<'a, T: 'a> {
                                                 data: &'a T,
-                                                fmt: fn(&T, &mut ::std::fmt::Formatter) -> ::std::fmt::Result,
+                                                fmt: fn(&T, &mut ::core::fmt::Formatter) -> ::core::fmt::Result,
                                             }
 
-                                            impl<'a, T: 'a> ::std::fmt::Debug for DebugWith<'a, T> {
-                                                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                                            impl<'a, T: 'a> ::core::fmt::Debug for DebugWith<'a, T> {
+                                                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                                                     (self.fmt)(self.data, f)
                                                 }
                                             }
@@ -108,8 +109,8 @@ fn custom_debug_derive(mut s: Structure) -> TokenStream {
     });
 
     s.gen_impl(quote! {
-        gen impl ::std::fmt::Debug for @Self {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        gen impl ::core::fmt::Debug for @Self {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 match self {
                     #variants
                 }
@@ -130,9 +131,9 @@ fn test_default_struct() {
 
         expands to {
             #[allow(non_upper_case_globals)]
-            const _DERIVE_std_fmt_Debug_FOR_Point: () = {
-                impl ::std::fmt::Debug for Point {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            const _DERIVE_core_fmt_Debug_FOR_Point: () = {
+                impl ::core::fmt::Debug for Point {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                         match self {
                             Point { x: ref __binding_0, y: ref __binding_1, } => {
                                 let mut s = f.debug_struct("Point");
@@ -161,9 +162,9 @@ fn test_format() {
 
         expands to {
             #[allow(non_upper_case_globals)]
-            const _DERIVE_std_fmt_Debug_FOR_Point: () = {
-                impl ::std::fmt::Debug for Point {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            const _DERIVE_core_fmt_Debug_FOR_Point: () = {
+                impl ::core::fmt::Debug for Point {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                         match self {
                             Point { x: ref __binding_0, y: ref __binding_1, } => {
                                 let mut s = f.debug_struct("Point");
@@ -194,20 +195,20 @@ fn test_with() {
 
         expands to {
             #[allow(non_upper_case_globals)]
-            const _DERIVE_std_fmt_Debug_FOR_Point: () = {
-                impl ::std::fmt::Debug for Point {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            const _DERIVE_core_fmt_Debug_FOR_Point: () = {
+                impl ::core::fmt::Debug for Point {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                         match self {
                             Point { x: ref __binding_0, y: ref __binding_1, } => {
                                 let mut s = f.debug_struct("Point");
                                 s.field("x", &{
                                     struct DebugWith<'a, T: 'a> {
                                         data: &'a T,
-                                        fmt: fn(&T, &mut ::std::fmt::Formatter) -> ::std::fmt::Result,
+                                        fmt: fn(&T, &mut ::core::fmt::Formatter) -> ::core::fmt::Result,
                                     }
 
-                                    impl<'a, T: 'a> ::std::fmt::Debug for DebugWith<'a, T> {
-                                        fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                                    impl<'a, T: 'a> ::core::fmt::Debug for DebugWith<'a, T> {
+                                        fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                                             (self.fmt)(self.data, f)
                                         }
                                     }
@@ -244,9 +245,9 @@ fn test_skip() {
 
         expands to {
             #[allow(non_upper_case_globals)]
-            const _DERIVE_std_fmt_Debug_FOR_Point: () = {
-                impl ::std::fmt::Debug for Point {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            const _DERIVE_core_fmt_Debug_FOR_Point: () = {
+                impl ::core::fmt::Debug for Point {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                         match self {
                             Point { x: ref __binding_0, z: ref __binding_2, .. } => {
                                 let mut s = f.debug_struct("Point");
@@ -276,9 +277,9 @@ fn test_enum() {
 
         expands to {
             #[allow(non_upper_case_globals)]
-            const _DERIVE_std_fmt_Debug_FOR_Foo: () = {
-                impl ::std::fmt::Debug for Foo {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            const _DERIVE_core_fmt_Debug_FOR_Foo: () = {
+                impl ::core::fmt::Debug for Foo {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                         match self {
                             Foo::Bar(ref __binding_0, ref __binding_1,) => {
                                 let mut s = f.debug_tuple("Bar");
@@ -332,12 +333,12 @@ fn test_bounds_on_skipped() {
 
         expands to {
             #[allow(non_upper_case_globals)]
-            const _DERIVE_std_fmt_Debug_FOR_WantDebug: () = {
-                impl<T> ::std::fmt::Debug for WantDebug<T>
+            const _DERIVE_core_fmt_Debug_FOR_WantDebug: () = {
+                impl<T> ::core::fmt::Debug for WantDebug<T>
                     where
-                        TemplatedType<T>: ::std::fmt::Debug
+                        TemplatedType<T>: ::core::fmt::Debug
                 {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                         match self {
                             WantDebug { foo: ref __binding_0, .. } => {
                                 let mut s = f.debug_struct("WantDebug");
@@ -376,13 +377,13 @@ fn test_bounds_on_fields_only() {
 
         expands to {
             #[allow(non_upper_case_globals)]
-            const _DERIVE_std_fmt_Debug_FOR_WantDebug: () = {
-                impl<T> ::std::fmt::Debug for WantDebug<T>
+            const _DERIVE_core_fmt_Debug_FOR_WantDebug: () = {
+                impl<T> ::core::fmt::Debug for WantDebug<T>
                     where
-                        TemplatedType<T>: ::std::fmt::Debug,
-                        T: ::std::fmt::Debug
+                        TemplatedType<T>: ::core::fmt::Debug,
+                        T: ::core::fmt::Debug
                 {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                         match self {
                             WantDebug { foo: ref __binding_0, bar: ref __binding_1, needs_debug: ref __binding_2, } => {
                                 let mut s = f.debug_struct("WantDebug");


### PR DESCRIPTION
This works on my 2018 edition crate, but might need changes to work with the 2015 edition. This might be a good opportunity to add tests for both cases so they don't regress.

Closes #6 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/custom_debug_derive/7)
<!-- Reviewable:end -->
