### PR TITLE
Dep updates!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-synstructure = "0.10.1"
-proc-macro2 = "0.4.30"
-syn = "0.15.34"
+synstructure = "0.12.3"
+proc-macro2 = "1.0.6"
+syn = "1.0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,9 @@
-extern crate proc_macro2;
-extern crate syn;
-#[macro_use]
-extern crate synstructure;
-
 use proc_macro2::TokenStream;
 use syn::{parse_str, Fields, Ident, Lit, Meta, NestedMeta, Path};
-use synstructure::{AddBounds, BindingInfo, Structure};
+use synstructure::{decl_derive, quote, AddBounds, BindingInfo, Structure};
+
+#[cfg(test)]
+use synstructure::test_derive;
 
 decl_derive!([CustomDebug, attributes(debug)] => custom_debug_derive);
 


### PR DESCRIPTION
And removing `extern crate`. :)

The major benefit of these changes is that we move to `syn`/`quote` 1.0.*,
which will help downstream compile times and defragment the ecosystem s'more.

The commits should be descriptive enough otherwise!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/custom_debug_derive/8)
<!-- Reviewable:end -->
